### PR TITLE
manifest: Parse information about sign interpretation

### DIFF
--- a/src/core/api/track_choice_manager.ts
+++ b/src/core/api/track_choice_manager.ts
@@ -71,6 +71,7 @@ interface ITMVideoRepresentation { id : string|number;
 
 /** Video track returned by the TrackChoiceManager. */
 export interface ITMVideoTrack { id : number|string;
+                                 signInterpreted?: boolean;
                                  representations: ITMVideoRepresentation[]; }
 
 /** Audio track from a list of audio tracks returned by the TrackChoiceManager. */
@@ -579,9 +580,13 @@ export default class TrackChoiceManager {
     if (chosenVideoAdaptation == null) {
       return null;
     }
-    return { id: chosenVideoAdaptation.id,
+    const videoTrack: ITMVideoTrack = { id: chosenVideoAdaptation.id,
              representations: chosenVideoAdaptation.representations
                                 .map(parseVideoRepresentation) };
+    if (chosenVideoAdaptation.isSignInterpreted === true) {
+      videoTrack.signInterpreted = true;
+    }
+    return videoTrack;
   }
 
   /**
@@ -668,12 +673,16 @@ export default class TrackChoiceManager {
 
     return videoInfos.adaptations
       .map((adaptation) => {
-        return {
+        const formatted: ITMVideoTrackListItem = {
           id: adaptation.id,
           active: currentId === null ? false :
                                        currentId === adaptation.id,
           representations: adaptation.representations.map(parseVideoRepresentation),
         };
+        if (adaptation.isSignInterpreted === true) {
+          formatted.signInterpreted = true;
+        }
+        return formatted;
     });
   }
 

--- a/src/manifest/adaptation.ts
+++ b/src/manifest/adaptation.ts
@@ -56,6 +56,7 @@ export interface IRepresentationInfos { bufferType: IAdaptationType;
                                         isAudioDescription? : boolean;
                                         isClosedCaption? : boolean;
                                         isDub? : boolean;
+                                        isSignInterpreted?: boolean;
                                         normalizedLanguage? : string; }
 
 /** Type for the `representationFilter` API. */
@@ -89,6 +90,12 @@ export default class Adaptation {
 
   /** Whether this Adaptation contains closed captions for the hard-of-hearing. */
   public isClosedCaption? : boolean;
+
+  /**
+   * If true this Adaptation is sign interpreted: which is a
+   * variant in sign language.
+   */
+  public isSignInterpreted? : boolean;
 
   /**
    * If `true`, this Adaptation is a "dub", meaning it was recorded in another
@@ -161,6 +168,9 @@ export default class Adaptation {
     if (parsedAdaptation.isDub !== undefined) {
       this.isDub = parsedAdaptation.isDub;
     }
+    if (parsedAdaptation.isSignInterpreted !== undefined) {
+      this.isSignInterpreted = parsedAdaptation.isSignInterpreted;
+    }
 
     this.representations = argsRepresentations
       .map(representation => new Representation(representation))
@@ -175,7 +185,8 @@ export default class Adaptation {
                                       normalizedLanguage: this.normalizedLanguage,
                                       isClosedCaption: this.isClosedCaption,
                                       isDub: this.isDub,
-                                      isAudioDescription: this.isAudioDescription });
+                                      isAudioDescription: this.isAudioDescription,
+                                      isSignInterpreted: this.isSignInterpreted });
       });
 
     // for manuallyAdded adaptations (not in the manifest)

--- a/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
+++ b/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
@@ -228,6 +228,7 @@ function createManifest(
               closedCaption: currentAdaptation.isClosedCaption,
               isDub: currentAdaptation.isDub,
               language: currentAdaptation.language,
+              isSignInterpreted: currentAdaptation.isSignInterpreted,
             });
             acc[type] = adaptationsForCurrentType;
           }

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -124,6 +124,11 @@ export interface IParsedAdaptation {
    */
   isDub? : boolean;
   /**
+   * If true this Adaptation is in a sign interpreted: which is a variant of the
+   * video with sign language.
+   */
+  isSignInterpreted? : boolean;
+  /**
    * Language the `Adaptation` is in.
    * Not set if unknown or if it makes no sense for the current track.
    */


### PR DESCRIPTION
We would like to incorporate the ability to switch between accessibility variants of the video in the player. In order to do so, our thought is to add another video adaptation set with the following role, following the [dash-if](https://dashif.org/docs/DASH-IF-IOP-v4.3.pdf) specification:

```
<AdaptationSet id="1" contentType="video" ...>
   <Role schemeIdUri="urn:mpeg:dash:role:2011" value="sign"/>
...
```

So what this change does is to add this information to the concerned video tracks following the same flow as the dub, audio description and etc.

I couldn't find anything related to sign interpretation variants in the dvb-specification tough, which I see you have based the other accessibility roles on. To be honest, I'm not very familiar with dash specifications, so I don't know whether it would be reasonable or not to add changes like this?

